### PR TITLE
Fix pluck query mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `pluck` and `pluck_col` no longer mutate the collection query or run eager-loading hooks.
+
 ## [v0.18.2] - 2026-06-10
 
 ### Fixed

--- a/spec/model/model_spec.cr
+++ b/spec/model/model_spec.cr
@@ -38,6 +38,36 @@ module ModelSpec
         end
       end
 
+      it "pluck does not mutate selected columns" do
+        temporary do
+          reinit_example_models
+          User.create!(id: 1, first_name: "John", middle_name: "William")
+
+          users = User.query.where(id: 1)
+          sql = users.to_sql
+
+          users.pluck_col("first_name").should eq(["John"])
+          users.to_sql.should eq(sql)
+          users.each(&.first_name.should(eq("John")))
+        end
+      end
+
+      it "pluck does not run eager loading hooks" do
+        temporary do
+          reinit_example_models
+          User.create!(id: 1, first_name: "John")
+
+          hook_called = false
+          users = User.query.with_posts { hook_called = true }
+
+          users.pluck_col("first_name").should eq(["John"])
+          hook_called.should be_false
+
+          users.each { }
+          hook_called.should be_true
+        end
+      end
+
       it "exists?" do
         temporary do
           reinit_example_models

--- a/src/lustra/sql/query/pluck.cr
+++ b/src/lustra/sql/query/pluck.cr
@@ -24,7 +24,7 @@ module Lustra::SQL::Query::Pluck
   def pluck_col(field : Lustra::SQL::Symbolic) : Array(Lustra::SQL::Any)
     field = Lustra::SQL.escape(field) if field.is_a?(Symbol)
 
-    sql = clear_select.select(field).to_sql
+    sql = dup.clear_before_query_triggers.clear_select.select(field).to_sql
 
     Lustra::SQL::ConnectionPool.with_connection(connection_name) do |cnx|
       rs = Lustra::SQL.log_query(sql) { cnx.query(sql) }
@@ -44,7 +44,7 @@ module Lustra::SQL::Query::Pluck
   def pluck_col(field : Lustra::SQL::Symbolic, type : T.class) : Array(T) forall T
     field = Lustra::SQL.escape(field) if field.is_a?(Symbol)
 
-    sql = clear_select.select(field).to_sql
+    sql = dup.clear_before_query_triggers.clear_select.select(field).to_sql
 
     Lustra::SQL::ConnectionPool.with_connection(connection_name) do |cnx|
       rs = Lustra::SQL.log_query(sql) { cnx.query(sql) }
@@ -76,7 +76,7 @@ module Lustra::SQL::Query::Pluck
   # :ditto:
   def pluck(fields : Tuple(*T)) forall T
     select_clause = fields.join(", ") { |f| f.is_a?(Symbol) ? Lustra::SQL.escape(f) : f.to_s }
-    sql = clear_select.select(select_clause).to_sql
+    sql = dup.clear_before_query_triggers.clear_select.select(select_clause).to_sql
 
     Lustra::SQL::ConnectionPool.with_connection(connection_name) do |cnx|
       rs = Lustra::SQL.log_query(sql) { cnx.query(sql) }
@@ -100,7 +100,7 @@ module Lustra::SQL::Query::Pluck
   # User.query.pluck(id: Int64, "UPPER(last_name)": String).each do #...
   # ```
   def pluck(**fields : **T) forall T
-    sql = clear_select.select(fields.keys.join(", ")).to_sql
+    sql = dup.clear_before_query_triggers.clear_select.select(fields.keys.join(", ")).to_sql
 
     Lustra::SQL::ConnectionPool.with_connection(connection_name) do |cnx|
       rs = Lustra::SQL.log_query(sql) { cnx.query(sql) }


### PR DESCRIPTION
## Summary

- Make `pluck` and `pluck_col` execute against an isolated query duplicate.
- Prevent `pluck` helpers from mutating the original collection `SELECT` clause.
- Skip eager-loading `before_query` hooks during pluck operations.